### PR TITLE
docs: add Node CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Node CI](https://github.com/lizc-au/my-first-project/actions/workflows/ci.yml/badge.svg)](https://github.com/lizc-au/my-first-project/actions/workflows/ci.yml)
+
 # my-first-project
 
 Mucking about
+


### PR DESCRIPTION
Add a live Node CI status badge to README.

What
- Inserts Actions badge for .github/workflows/ci.yml at the top of README.

Why
- Quick glance CI health indicator for collaborators and future me.

Test Plan
- Badge should render on the repo home page and link to the CI workflow runs.
- CI should still pass (docs only).

Notes
- No code or config changes.
