### PR TITLE
Ci/add dependabot 2025 09 12

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,20 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: "/"
+    directory: '/'
     schedule:
       interval: weekly
       day: sunday
-      time: "01:00"
+      time: '01:00'
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "deps"
+      prefix: 'deps'
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: '/'
     schedule:
       interval: weekly
       day: sunday
-      time: "01:00"
+      time: '01:00'
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "ci"
+      prefix: 'ci'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,1 +1,20 @@
-version: 2rnupdates:rn - package-ecosystem: npmrn directory: "/"rn schedule:rn interval: weeklyrn day: sundayrn time: "01:00"rn open-pull-requests-limit: 5rn commit-message:rn prefix: "deps"rn - package-ecosystem: github-actionsrn directory: "/"rn schedule:rn interval: weeklyrn day: sundayrn time: "01:00"rn open-pull-requests-limit: 5rn commit-message:rn prefix: "ci"
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: "01:00"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: "01:00"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,1 @@
+version: 2rnupdates:rn - package-ecosystem: npmrn directory: "/"rn schedule:rn interval: weeklyrn day: sundayrn time: "01:00"rn open-pull-requests-limit: 5rn commit-message:rn prefix: "deps"rn - package-ecosystem: github-actionsrn directory: "/"rn schedule:rn interval: weeklyrn day: sundayrn time: "01:00"rn open-pull-requests-limit: 5rn commit-message:rn prefix: "ci"


### PR DESCRIPTION
Enable Dependabot to keep npm deps and GitHub Actions up to date.

What
- Adds `.github/dependabot.yml` with weekly checks (Sundays 01:00) for:
  - npm packages
  - GitHub Actions
- Caps open PRs at 5; commit prefixes: "deps" (npm) and "ci" (Actions).

Why
- Automates updates to reduce security risk and maintenance toil.

Test/Merge
- CI should pass (config-only change).
- After merge, expect Dependabot PRs within a day or on the next schedule.
