### PR TITLE
chore: husky pre-commit runs lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+#!/usr/bin/env shnnpx lint-staged


### PR DESCRIPTION
Add Husky + lint-staged to enforce formatting/lint fixes before commits.

What
- Installs Husky v9 and lint-staged.
- Adds `prepare` script and lint-staged config in package.json:
  - Prettier on *.{js,cjs,json,yml,yaml,md}
  - ESLint --fix on src/**/*.js
- Adds .husky/pre-commit to run `npx lint-staged`.

Why
- Catch and auto-fix style issues before code reaches CI.

Test/Merge
- Local: try `git commit` with a small JS change and see lint-staged run.
- CI: no behavior change (hooks only run locally). Should pass as config-only.
