### PR TITLE
chore: add .editorconfig (LF, 2 spaces)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+[*.ps1]
+end_of_line = crlf
+
+[*.bat]
+end_of_line = crlf
+
+[*.cmd]
+end_of_line = crlf


### PR DESCRIPTION
Introduce a repo-wide .editorconfig.

What
- Sets LF EOL, UTF-8 charset, 2-space indentation, final newline.
- Overrides: CRLF for *.ps1, *.bat, *.cmd.

Why
- Consistent line endings and indentation across tools/OS.
- Reduces diff noise and CI formatting warnings.

Test/Merge
- Config-only; CI should pass.
- After merge, editors honoring EditorConfig will apply settings automatically.
