### PR TITLE
Docs/readme troubleshooting 2025 09 12

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+[*.ps1]
+end_of_line = crlf
+
+[*.bat]
+end_of_line = crlf
+
+[*.cmd]
+end_of_line = crlf

--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@
 
 Mucking about
 
+
+## Troubleshooting
+- If Chrome crashes opening http://localhost:3000, try http://127.0.0.1:3000 or another browser (Edge/Firefox), or disable Use hardware acceleration in Chrome Settings > System.
+- Verify without a browser:
+ - PowerShell: Invoke-RestMethod http://localhost:3000/api/health
+ - POST echo: Invoke-RestMethod -Method POST -Uri http://localhost:3000/api/echo -Body (@{msg='hi'}|ConvertTo-Json) -ContentType 'application/json'


### PR DESCRIPTION
Add troubleshooting notes for accessing the local dev server.

What
- Tips for Chrome GPU crashes: try 127.0.0.1 or disable hardware acceleration.
- PowerShell examples to verify API without a browser.

Why
- Helps avoid confusion when the browser misbehaves while the server is fine.

Notes
- Docs only; CI unaffected.
